### PR TITLE
Reduce Docker image size

### DIFF
--- a/ament_lint_pre_commit_hooks/Dockerfile
+++ b/ament_lint_pre_commit_hooks/Dockerfile
@@ -1,8 +1,9 @@
-FROM ros:rolling
+# Use the bare minimum ROS rolling image as a base
+FROM ros:rolling-ros-core
 
-# Install ament_lint and ament_mypy
+# Install only essential packages from ament_lint and ament_mypy
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get install -y --no-install-recommends \
     ros-rolling-ament-lint \
     ros-rolling-ament-mypy \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Description of contribution in a few bullet points
* Use `ros:rolling-ros-core` instead of the full-fledged desktop image.
* Added `--no-install-recommends` to install only necessary packages.

## Description of how this change was tested
* N/A
